### PR TITLE
Ignore stacked layouts.

### DIFF
--- a/autotiling.py
+++ b/autotiling.py
@@ -32,10 +32,11 @@ def switch_splitting(i3, e):
             # On sway on 1st focus the parent container returns 1, then forever the focused container itself
             is_full_screen = con.fullscreen_mode == 1 or con.parent.fullscreen_mode == 1
 
+        is_stacked = con.parent.layout == 'stacked'
         is_tabbed = con.parent.layout == 'tabbed'
 
-        # Let's exclude floating containers, tabbed layouts and full screen mode
-        if not is_floating and not is_tabbed and not is_full_screen:
+        # Let's exclude floating containers, stacked layouts, tabbed layouts and full screen mode
+        if not is_floating and not is_stacked and not is_tabbed and not is_full_screen:
             new_layout = 'splitv' if con.rect.height > con.rect.width else 'splith'
             i3.command(new_layout)
 


### PR DESCRIPTION
This PR ignores stacked layouts so that sway does not create implicit containers for every new stacked window.