### PR TITLE
Only run command if absolutely necessary

### DIFF
--- a/autotiling.py
+++ b/autotiling.py
@@ -39,7 +39,8 @@ def switch_splitting(i3, e):
             # Let's exclude floating containers, stacked layouts, tabbed layouts and full screen mode
             if not is_floating and not is_stacked and not is_tabbed and not is_full_screen:
                 new_layout = 'splitv' if con.rect.height > con.rect.width else 'splith'
-                i3.command(new_layout)
+                if new_layout != con.parent.layout:
+                    i3.command(new_layout)
 
     except Exception as e:
         print('Error: {}'.format(e))


### PR DESCRIPTION
Have been investigating an [issue](https://github.com/altdesktop/i3ipc-python/issues/147#issue-566508757) I encountered while running `autotiling` in which millions of calls were being made to the IPC socket.

While this PR isn't a fix for that issue, it's still an improvement that could be made.