### PR TITLE
Changed a small error in the debugging system

### DIFF
--- a/autotiling.py
+++ b/autotiling.py
@@ -44,7 +44,7 @@ def switch_splitting(i3, e, debug):
                     result = i3.command(new_layout)
                     if result[0].success and debug:
                         print('Debug: Switched to {}'.format(new_layout), file=sys.stderr)
-                    else:
+                    elif debug:
                         print('Error: Switch failed with err {}'.format(result[0].error), file=sys.stderr)
 
         elif debug:


### PR DESCRIPTION
There were an error in the debug conditions, leading the program to display errors of type "None" when there were no --debug flag and no error (instead of nothing). It's fixed now!