### PR TITLE
Don't recommend exec_always to prevent fork on config reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ Inspired by https://github.com/olemartinorg/i3-alternating-layout
 **Arch Linux**
 
 1. Install the `autotiling` (AUR) package.
-2. Add `exec --no-startup-id autotiling` to the `~/.config/sway/config` or to the `~/.config/i3/config` file.
+2. Add `exec autotiling` to the `~/.config/sway/config` or `exec --no-startup-id autotiling` to the `~/.config/i3/config` file.
 
 
 **Manually**
 
 1. Install the `python-i3ipc>=2.0.1` package (or whatever it's called in your Linux distribution).
 2. Save the `autotiling.py` file anywhere, make executable and autostart in your i3/sway config file: 
-`exec --no-startup-id /path/to/the/script/autotiling.py` on sway or i3.
+`exec /path/to/the/script/autotiling.py` on sway or `exec --no-startup-id /path/to/the/script/autotiling.py` on i3.


### PR DESCRIPTION
`exec_always` launches a new instance every time config reloading occurs, which lead me to spawn 50 instances of Autotiling as I was changing my sway config. 

This behaviour is the same in i3, `exec` and `exec_always` both work the same in i3 and sway, there is no reason to talk about them differently.

`exec` does not spawn a new instance of the application every time the config is reloaded, which means you don't fork bomb your computer :D

The --no-startup-id is just something I've always done for apps that don't take place in a certain workspace, autotiling fits this description.