### PR TITLE
Fixed manually switching between layouts not working

### DIFF
--- a/autotiling/main.py
+++ b/autotiling/main.py
@@ -113,8 +113,7 @@ def main():
 
     handler = partial(switch_splitting, debug=args.debug, workspaces=args.workspaces)
     i3 = Connection()
-    i3.on(Event.WINDOW_FOCUS, handler)
-    i3.on(Event.BINDING, handler)
+    i3.on(Event.WINDOW, handler)
     i3.main()
 
 

--- a/autotiling/main.py
+++ b/autotiling/main.py
@@ -114,6 +114,7 @@ def main():
     handler = partial(switch_splitting, debug=args.debug, workspaces=args.workspaces)
     i3 = Connection()
     i3.on(Event.WINDOW, handler)
+    i3.on(Event.MODE, handler)
     i3.main()
 
 


### PR DESCRIPTION
Fixes this layout change issue:

https://user-images.githubusercontent.com/35975961/138968708-9f25fc71-83d2-4188-a794-3562bef9eb28.mp4

Also fixes this issue where the indicator (the light blue indicator) doesn't update when closing a non-disowned application from the terminal. Look at the right terminals indicator

https://user-images.githubusercontent.com/35975961/138969594-af05399a-b05f-4a14-b8c1-602c7ace9b03.mp4

Removing the `BINDING` event fixed the indicator updating issue while using the `WINDOW` event instead of `WINDOW_Focus` updates more often.