### PR TITLE
Add publish to PYPI workflow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,34 @@
+# This workflow will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+    - name: Build package
+      run: python -m build
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /autotiling.egg-info/
 /build/
 /dist/
+**/*.DS_Store

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = autotiling
-version = 1.6
+version = 1.6.1
 author = Piotr Miller
 author_email = nwg.piotr@gmail.com
 description = Automatically switch the horizontal/vertical window split orientation in sway and i3


### PR DESCRIPTION
Hi Again!

So we talked about this very briefly in #38. If you're still open automating the release to PyPi this GitHub Action workflow should do the trick. It's almost the stock workflow from the GitHub marketplace so nothing special. 

It run every time you publish a release on GitHub and only requires 1 environment variable/secret which is your PYPI API key saved as "PYPI_API_TOKEN" under the autotiling's repo settings. I'm happy to help if you're unfamiliar with any part of this process. 

I tested it using https://test.pypi.org which can be found here https://test.pypi.org/project/autotiling/ (i'll delete when this pull request is closed).

Talk when you're back from vacation, cheers!
