### PR TITLE
Add depth limit as argument for how often to autotile

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,17 +12,27 @@ action](https://img.youtube.com/vi/UWRZuhn92bQ/0.jpg)](https://www.youtube.com/w
 
 ## PLEASE DO READ THIS
 
-The script does one thing: it checks the window height / width ratio, and executes
-the equivalent of either `swaymsg splitv` or `swaymsg splith`. Nothing less, nothing more. Yes, it may make
-stacking and tabbed layouts behave oddly. No, nothing can be done about it. If you like stacking/tabbed layouts,
-you may use them on workspaces with autotiling turned off (`--workspaces` argument). Do not submit issues about it. 
+The script does one thing: it checks the window height / width ratio, and
+executes the equivalent of either `swaymsg splitv` or `swaymsg splith`. Nothing
+less, nothing more. This may make stack and tabbed layouts behave oddly.
+Unfortunately, there is nothing that can be done about it – please, do not
+submit issues about it –, but there are two workaround that you can try.
 
-For instance, you may configure autotiling to work on odd workspaces, but not on even:
+One option is, to enable autotiling on certain workspaces only. For instance,
+you could configure autotiling to be enabled on odd workspaces, but not on
+even ones:
 
 ```text
 ### Autostart
-  exec autotiling -w 1 3 5 7 9
+  exec_always autotiling -w 1 3 5 7 9
 ```
+
+Another option you can try, is setting `--limit` and only use stacking or
+tabbing on the lowest level. A good place to start would be `--limit 2`. Open
+four windows with the third and fourth window in the same container as two. This
+might mimic a master-stack layout and you should now be able to switch to
+stacking or tabbed. Beware that the decision on how to split is still based on
+the height / width ratio.
 
 ## Installation
 
@@ -54,6 +64,9 @@ optional arguments:
   -w [WORKSPACES ...], --workspaces [WORKSPACES ...]
                         restricts autotiling to certain workspaces; example: autotiling --workspaces 8
                         9
+  -l LIMIT, --limit LIMIT
+                        limit how often autotiling will split a container; try "2", if you like
+                        master-stack layouts; default: 0 (no limit)
   -e [EVENTS ...], --events [EVENTS ...]
                         list of events to trigger switching split orientation; default: WINDOW MODE
 ```

--- a/autotiling/main.py
+++ b/autotiling/main.py
@@ -63,12 +63,21 @@ def switch_splitting(i3, e, debug, workspaces, depth_limit):
                 # Assume we reached the depth limit, unless we can find a workspace
                 depth_limit_reached = True
                 current_con = con
-                for _ in range(depth_limit):
-                    # Check if parent of the current con is a workspace
-                    current_con = current_con.parent
+                current_depth = 0
+                while current_depth < depth_limit:
+                    # Check if we found the workspace of the current container
                     if current_con.type == "workspace":
                         # Found the workspace within the depth limitation
                         depth_limit_reached = False
+                        break
+
+                    # Look at the parent for next iteration
+                    current_con = current_con.parent
+
+                    # Only count up the depth, if the container has more than
+                    # one container as child
+                    if len(current_con.nodes) > 1:
+                        current_depth += 1
 
                 if depth_limit_reached:
                     if debug:

--- a/autotiling/main.py
+++ b/autotiling/main.py
@@ -128,7 +128,8 @@ def main():
                         default=[], )
     parser.add_argument("-l",
                         "--limit",
-                        help="limit how often autotiling will split a container; default: 0 (no limit)",
+                        help='limit how often autotiling will split a container; '
+                        'try "2", if you like master-stack layouts; default: 0 (no limit)',
                         type=int,
                         default=0, )
     """


### PR DESCRIPTION
Currently the script will autotile (vsplit/hsplit) every window focused on with no limit.

At a certain depth this behaviour is not desirably to me and I want to add more windows to the same container. Especially for terminals I prefer to have more space horizontally than vertically to see the entire line if possible.

To achieve this, I add a optional parameter to prevent further autotiling after the specified limit. For example with a 16:9 display and a depth limit of 1, it will split horizontally first and then only split vertically but in the same container.
```
 ________________
|        |       |
|--------|       |
|        |-------|
|--------|       |
|________|_______|
```
As a side effect, this enables stacking and tabbed layouts after reaching the limit.
The default behavior is still the same with an infinite limit for how deep to autotile.

Edit: I mainly made this for me. Not sure if you are interested in this.