### PR TITLE
Add option to limit to outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ less, nothing more. This may make stack and tabbed layouts behave oddly.
 Unfortunately, there is nothing that can be done about it – please, do not
 submit issues about it –, but there are two workaround that you can try.
 
-One option is, to enable autotiling on certain workspaces only. For instance,
-you could configure autotiling to be enabled on odd workspaces, but not on
-even ones:
+One option is, to enable autotiling on certain workspaces or outputs only.
+For instance, you could configure autotiling to be enabled on odd workspaces,
+but not on even ones:
 
 ```text
 ### Autostart
@@ -61,6 +61,9 @@ optional arguments:
   -h, --help            show this help message and exit
   -d, --debug           print debug messages to stderr
   -v, --version         display version information
+  -o [OUTPUTS ...], --outputs [OUTPUTS ...]
+                        restricts autotiling to certain output; example: autotiling --output DP-1
+                        HDMI-0
   -w [WORKSPACES ...], --workspaces [WORKSPACES ...]
                         restricts autotiling to certain workspaces; example: autotiling --workspaces 8
                         9

--- a/autotiling/main.py
+++ b/autotiling/main.py
@@ -47,9 +47,21 @@ def save_string(string, file):
         print(e)
 
 
+def output_name(con):
+    if con.type == "root":
+        return None
+
+    if p := con.parent:
+        if p.type == "output":
+            return p.name
+        else:
+            return output_name(p)
+
+
 def switch_splitting(i3, e, debug, outputs, workspaces, depth_limit):
     try:
-        output = e.ipc_data.get("container", {}).get("output", "")
+        con = i3.get_tree().find_focused()
+        output = output_name(con)
         # Stop, if outputs is set and current output is not in the selection
         if outputs and output not in outputs:
             if debug:
@@ -59,7 +71,6 @@ def switch_splitting(i3, e, debug, outputs, workspaces, depth_limit):
                 )
             return
 
-        con = i3.get_tree().find_focused()
         if con and not workspaces or (str(con.workspace().num) in workspaces):
             if con.floating:
                 # We're on i3: on sway it would be None


### PR DESCRIPTION
To enable different limits on different outputs, you can start two processes and limit them to the outputs you want.

Like suggested in #41.
I did not implement anything for nwg-panel to not break anything.