### PR TITLE
split ratio, split horizontal factor, split vert factor

### DIFF
--- a/autotiling/main.py
+++ b/autotiling/main.py
@@ -149,13 +149,13 @@ def main():
                         "--splitheight",
                         help='set the height of the horizontal split (as factor); default: 1.0;',
                         type=float,
-                        default=1, )
+                        default=1.0, )
     parser.add_argument("-sr",
                         "--splitratio",
                         help='Split direction ratio - based on window height/width; default: 1;'
-                        'try "1.61", for golden ratio - window has to be 61% wider for left/right split; default: 1.0;',
+                        'try "1.61", for golden ratio - window has to be 61%% wider for left/right split; default: 1.0;',
                         type=float,
-                        default=1, )
+                        default=1.0, )
     """
     Changing event subscription has already been the objective of several pull request. To avoid doing this again
     and again, let's allow to specify them in the `--events` argument.

--- a/autotiling/main.py
+++ b/autotiling/main.py
@@ -93,7 +93,7 @@ def switch_splitting(i3, e, debug, workspaces, depth_limit, splitwidth, splithei
                     and not is_stacked
                     and not is_tabbed
                     and not is_full_screen):
-                new_layout = "splitv" if con.rect.height > 1/splitratio*con.rect.width else "splith"
+                new_layout = "splitv" if con.rect.height > con.rect.width/splitratio else "splith"
 
                 if new_layout != con.parent.layout:
                     result = i3.command(new_layout)

--- a/autotiling/main.py
+++ b/autotiling/main.py
@@ -123,11 +123,11 @@ def switch_splitting(i3, e, debug, outputs, workspaces, depth_limit, splitwidth,
                     elif debug:
                         print("Error: Switch failed with err {}".format(result[0].error), file=sys.stderr, )
 
-                if e.change == "new" and con.percent:
-                    if con.parent.layout == "splitv": # top / bottom
+                if e.change in ["new","move"] and con.percent:
+                    if con.parent.layout == "splitv" and splitheight != 1.0: # top / bottom
                         # print(f"split top fac {splitheight*100}")
                         i3.command(f"resize set height {int(con.percent*splitheight*100)} ppt")
-                    else:                     # left / right
+                    elif con.parent.layout == "splith" and splitwidth != 1.0: # top / bottom:                     # left / right
                         # print(f"split right fac {splitwidth*100} ")
                         i3.command(f"resize set width {int(con.percent*splitwidth*100)} ppt")
 
@@ -221,8 +221,8 @@ def main():
         outputs=args.outputs,
         workspaces=args.workspaces,
         depth_limit=args.limit,
-        splitwidth=args.splitwidth, 
-        splitheight=args.splitheight, 
+        splitwidth=args.splitwidth,
+        splitheight=args.splitheight,
         splitratio=args.splitratio
     )
     i3 = Connection()

--- a/autotiling/main.py
+++ b/autotiling/main.py
@@ -147,13 +147,13 @@ def main():
                         default=1.0, )
     parser.add_argument("-sh",
                         "--splitheight",
-                        help='set the height of the horizontal split (as factor); default: 0.5;',
+                        help='set the height of the horizontal split (as factor); default: 1.0;',
                         type=float,
                         default=1, )
     parser.add_argument("-sr",
                         "--splitratio",
                         help='Split direction ratio - based on window height/width; default: 1;'
-                        'try "1.61", for golden ratio - window has to be 61% wider for left/right split; default: 1;',
+                        'try "1.61", for golden ratio - window has to be 61% wider for left/right split; default: 1.0;',
                         type=float,
                         default=1, )
     """


### PR DESCRIPTION
split ratio - for example 2 => window has to be 2x wider than normal, before left right split is done.
split widht - 0.8 => reduce size of new window 20% when left/right split
split height - similar to above for top/bottom splits

```python
    parser.add_argument("-sw",
                        "--splitwidth",
                        help='set the width of the vertical split (as factor); default: 1.0;',
                        type=float,
                        default=1.0, )
    parser.add_argument("-sh",
                        "--splitheight",
                        help='set the height of the horizontal split (as factor); default: 1.0;',
                        type=float,
                        default=1, )
    parser.add_argument("-sr",
                        "--splitratio",
                        help='Split direction ratio - based on window height/width; default: 1;'
                        'try "1.61", for golden ratio - window has to be 61% wider for left/right split; default: 1;',
                        type=float,
                        default=1, )

```