### PR TITLE
Update actions versions and ingore existing PyPI versions

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -16,9 +16,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Install dependencies
@@ -28,7 +28,8 @@ jobs:
     - name: Build package
       run: python -m build
     - name: Publish package
-      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}
+        skip-existing: true


### PR DESCRIPTION
The actions checkout and setup-python have never versions and there is
currently an issue with uploading to PyPI (see #52).

This ups the versions for the GitHub Actions and lets the publish to
PyPI action skip existing versions since the cannot be changed after
publishing. See
https://github.com/pypa/gh-action-pypi-publish#tolerating-release-package-file-duplicates
