### PR TITLE
Exclude scratchpad move events

### DIFF
--- a/autotiling/main.py
+++ b/autotiling/main.py
@@ -62,16 +62,10 @@ def switch_splitting(i3, e, debug, outputs, workspaces, depth_limit, splitwidth,
 
         if con and not workspaces or (str(con.workspace().num) in workspaces):
             # May be 'auto_on' or 'user_on' in con.floating
-            # Or e.ipc_data.container.scratchpad_state has 'fresh' when a scratchpad container is hidden
-            # Or e.ipc_data.container.type has 'floating_con' when a scratchpad container is closed
+            # Or e.ipc_data.container.type has 'floating_con' when a container is moved to scratchpad or a scratchpad container is closed
             is_floating = ("_on" in con.floating
                            or
                            con.type == "floating_con"
-                           or
-                           e.ipc_data
-                           .get('container', {})
-                           .get('scratchpad_state')
-                           == 'fresh'
                            or
                            e.ipc_data
                            .get('container', {})

--- a/autotiling/main.py
+++ b/autotiling/main.py
@@ -67,7 +67,17 @@ def switch_splitting(i3, e, debug, outputs, workspaces, depth_limit, splitwidth,
                 is_floating = "_on" in con.floating
             else:
                 # We are on sway
-                is_floating = con.type == "floating_con"
+                is_floating = (con.type == "floating_con"
+                               or
+                               e.ipc_data
+                               .get('container', {})
+                               .get('scratchpad_state')
+                               == 'fresh'
+                               or
+                               e.ipc_data
+                               .get('container', {})
+                               .get('type') == 'floating_con'
+                               )
 
             if depth_limit:
                 # Assume we reached the depth limit, unless we can find a workspace
@@ -97,19 +107,12 @@ def switch_splitting(i3, e, debug, outputs, workspaces, depth_limit, splitwidth,
             is_full_screen = con.fullscreen_mode == 1
             is_stacked = con.parent.layout == "stacked"
             is_tabbed = con.parent.layout == "tabbed"
-            is_scratchpad = (
-                    e.ipc_data
-                    .get('container', {})
-                    .get('scratchpad_state')
-                    == 'fresh'
-                    )
 
-            # Exclude floating or scratchpad containers, stacked layouts, tabbed layouts and full screen mode
+            # Exclude floating containers, stacked layouts, tabbed layouts and full screen mode
             if (not is_floating
                     and not is_stacked
                     and not is_tabbed
-                    and not is_full_screen
-                    and not is_scratchpad):
+                    and not is_full_screen):
                 new_layout = "splitv" if con.rect.height > con.rect.width / splitratio else "splith"
 
                 if new_layout != con.parent.layout:

--- a/autotiling/main.py
+++ b/autotiling/main.py
@@ -101,7 +101,7 @@ def switch_splitting(i3, e, debug, outputs, workspaces, depth_limit, splitwidth,
                     e.ipc_data
                     .get('container', {})
                     .get('scratchpad_state')
-                    != 'none'
+                    == 'fresh'
                     )
 
             # Exclude floating or scratchpad containers, stacked layouts, tabbed layouts and full screen mode

--- a/autotiling/main.py
+++ b/autotiling/main.py
@@ -97,12 +97,19 @@ def switch_splitting(i3, e, debug, outputs, workspaces, depth_limit, splitwidth,
             is_full_screen = con.fullscreen_mode == 1
             is_stacked = con.parent.layout == "stacked"
             is_tabbed = con.parent.layout == "tabbed"
+            is_scratchpad = (
+                    e.ipc_data
+                    .get('container', {})
+                    .get('scratchpad_state')
+                    != 'none'
+                    )
 
-            # Exclude floating containers, stacked layouts, tabbed layouts and full screen mode
+            # Exclude floating or scratchpad containers, stacked layouts, tabbed layouts and full screen mode
             if (not is_floating
                     and not is_stacked
                     and not is_tabbed
-                    and not is_full_screen):
+                    and not is_full_screen
+                    and not is_scratchpad):
                 new_layout = "splitv" if con.rect.height > con.rect.width / splitratio else "splith"
 
                 if new_layout != con.parent.layout:

--- a/autotiling/main.py
+++ b/autotiling/main.py
@@ -61,23 +61,22 @@ def switch_splitting(i3, e, debug, outputs, workspaces, depth_limit, splitwidth,
             return
 
         if con and not workspaces or (str(con.workspace().num) in workspaces):
-            if con.floating:
-                # We're on i3: on sway it would be None
-                # May be 'auto_on' or 'user_on'
-                is_floating = "_on" in con.floating
-            else:
-                # We are on sway
-                is_floating = (con.type == "floating_con"
-                               or
-                               e.ipc_data
-                               .get('container', {})
-                               .get('scratchpad_state')
-                               == 'fresh'
-                               or
-                               e.ipc_data
-                               .get('container', {})
-                               .get('type') == 'floating_con'
-                               )
+            # May be 'auto_on' or 'user_on' in con.floating
+            # Or e.ipc_data.container.scratchpad_state has 'fresh' when a scratchpad container is hidden
+            # Or e.ipc_data.container.type has 'floating_con' when a scratchpad container is closed
+            is_floating = ("_on" in con.floating
+                           or
+                           con.type == "floating_con"
+                           or
+                           e.ipc_data
+                           .get('container', {})
+                           .get('scratchpad_state')
+                           == 'fresh'
+                           or
+                           e.ipc_data
+                           .get('container', {})
+                           .get('type') == 'floating_con'
+                           )
 
             if depth_limit:
                 # Assume we reached the depth limit, unless we can find a workspace

--- a/autotiling/main.py
+++ b/autotiling/main.py
@@ -53,6 +53,22 @@ def output_name(con):
 def switch_splitting(i3, e, debug, outputs, workspaces, depth_limit, splitwidth, splitheight, splitratio):
     try:
         con = i3.get_tree().find_focused()
+        # May be 'auto_on' or 'user_on' in con.floating
+        is_floating = "_on" in con.floating or con.type == "floating_con"
+        is_full_screen = con.fullscreen_mode == 1
+        is_stacked = con.parent.layout == "stacked"
+        is_tabbed = con.parent.layout == "tabbed"
+        is_event_con_focused = con.id == e.ipc_data.get("container", {}).get("id")
+
+        # Exclude floating containers, stacked layouts, tabbed layouts, full screen mode
+        # Also exclude if focused container is not the one that triggered the event
+        if (is_floating
+                or is_stacked
+                or is_tabbed
+                or is_full_screen
+                or not is_event_con_focused):
+            return
+
         output = output_name(con)
         # Stop, if outputs is set and current output is not in the selection
         if outputs and output not in outputs:
@@ -60,71 +76,52 @@ def switch_splitting(i3, e, debug, outputs, workspaces, depth_limit, splitwidth,
                 print(f"Debug: Autotiling turned off on output {output}", file=sys.stderr)
             return
 
-        if con and not workspaces or (str(con.workspace().num) in workspaces):
-            # May be 'auto_on' or 'user_on' in con.floating
-            # Or e.ipc_data.container.type has 'floating_con' when a container is moved to scratchpad or a scratchpad container is closed
-            is_floating = ("_on" in con.floating
-                           or
-                           con.type == "floating_con"
-                           or
-                           e.ipc_data
-                           .get('container', {})
-                           .get('type') == 'floating_con'
-                           )
+        if not con or workspaces and str(con.workspace().num) not in workspaces:
+            if debug:
+                print("Debug: No focused container found or autotiling on the workspace turned off", file=sys.stderr)
+            return
 
-            if depth_limit:
-                # Assume we reached the depth limit, unless we can find a workspace
-                depth_limit_reached = True
-                current_con = con
-                current_depth = 0
-                while current_depth < depth_limit:
-                    # Check if we found the workspace of the current container
-                    if current_con.type == "workspace":
-                        # Found the workspace within the depth limitation
-                        depth_limit_reached = False
-                        break
+        if depth_limit:
+            # Assume we reached the depth limit, unless we can find a workspace
+            depth_limit_reached = True
+            current_con = con
+            current_depth = 0
+            while current_depth < depth_limit:
+                # Check if we found the workspace of the current container
+                if current_con.type == "workspace":
+                    # Found the workspace within the depth limitation
+                    depth_limit_reached = False
+                    break
 
-                    # Look at the parent for next iteration
-                    current_con = current_con.parent
+                # Look at the parent for next iteration
+                current_con = current_con.parent
 
-                    # Only count up the depth, if the container has more than
-                    # one container as child
-                    if len(current_con.nodes) > 1:
-                        current_depth += 1
+                # Only count up the depth, if the container has more than
+                # one container as child
+                if len(current_con.nodes) > 1:
+                    current_depth += 1
 
-                if depth_limit_reached:
-                    if debug:
-                        print("Debug: Depth limit reached")
-                    return
+            if depth_limit_reached:
+                if debug:
+                    print("Debug: Depth limit reached")
+                return
 
-            is_full_screen = con.fullscreen_mode == 1
-            is_stacked = con.parent.layout == "stacked"
-            is_tabbed = con.parent.layout == "tabbed"
+        new_layout = "splitv" if con.rect.height > con.rect.width / splitratio else "splith"
 
-            # Exclude floating containers, stacked layouts, tabbed layouts and full screen mode
-            if (not is_floating
-                    and not is_stacked
-                    and not is_tabbed
-                    and not is_full_screen):
-                new_layout = "splitv" if con.rect.height > con.rect.width / splitratio else "splith"
+        if new_layout != con.parent.layout:
+            result = i3.command(new_layout)
+            if result[0].success and debug:
+                print(f"Debug: Switched to {new_layout}", file=sys.stderr)
+            elif debug:
+                print(f"Error: Switch failed with err {result[0].error}", file=sys.stderr)
 
-                if new_layout != con.parent.layout:
-                    result = i3.command(new_layout)
-                    if result[0].success and debug:
-                        print(f"Debug: Switched to {new_layout}", file=sys.stderr)
-                    elif debug:
-                        print(f"Error: Switch failed with err {result[0].error}", file=sys.stderr)
-
-                if e.change in ["new", "move"] and con.percent:
-                    if con.parent.layout == "splitv" and splitheight != 1.0:  # top / bottom
-                        # print(f"split top fac {splitheight*100}")
-                        i3.command(f"resize set height {int(con.percent * splitheight * 100)} ppt")
-                    elif con.parent.layout == "splith" and splitwidth != 1.0:  # top / bottom:                     # left / right
-                        # print(f"split right fac {splitwidth*100} ")
-                        i3.command(f"resize set width {int(con.percent * splitwidth * 100)} ppt")
-
-        elif debug:
-            print("Debug: No focused container found or autotiling on the workspace turned off", file=sys.stderr)
+        if e.change in ["new", "move"] and con.percent:
+            if con.parent.layout == "splitv" and splitheight != 1.0:  # top / bottom
+                # print(f"split top fac {splitheight*100}")
+                i3.command(f"resize set height {int(con.percent * splitheight * 100)} ppt")
+            elif con.parent.layout == "splith" and splitwidth != 1.0:  # top / bottom:                     # left / right
+                # print(f"split right fac {splitwidth*100} ")
+                i3.command(f"resize set width {int(con.percent * splitwidth * 100)} ppt")
 
     except Exception as e:
         print(f"Error: {e}", file=sys.stderr)


### PR DESCRIPTION
This change fixes a bug that caused the parent container
to resize incorrectly when a scratchpad window was hidden.

To reproduce the bug:
1. Run `autotiling --splitwidth 0.9`.
2. Create three windows.
3. Move the third window to the scratchpad.
4. Focus on the first (left) window.
5. Show the window from the scratchpad and then hide it again.
6. The first window is resized to an unusually small size.

Environment:
- Sway